### PR TITLE
Update test environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 npm-debug.log
 .DS_Store
 .*.swp
-components/
+bower_components/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "fix": "fixjsstyle --strict --nojsdoc -r ./lib -r ./test ./inedx.js",
     "lint": "gjslint --strict --nojsdoc -r ./lib -r ./test ./index.js",
     "mini": "uglifyjs ./lib/deepcopy.js --comments -cmr deepcopy -o ./deepcopy.min.js",
-    "test": "mocha",
-    "testem": "testem ci"
+    "test": "node_modules/mocha/bin/mocha",
+    "testem": "node_modules/testem/testem.js ci"
   },
   "devDependencies": {
-    "bower": "~0.9",
-    "chai": "~1.6",
+    "bower": "~1.2",
+    "chai": "~1.7",
     "mocha": "~1.11",
-    "testem": "~0.2",
+    "testem": "~0.3",
     "uglify-js": "~2.3"
   }
 }

--- a/test/test-deepcopy.html
+++ b/test/test-deepcopy.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>test of deepcopy</title>
-<link rel="stylesheet" href="../components/mocha/mocha.css">
+<link rel="stylesheet" href="../bower_components/mocha/mocha.css">
 <div id="mocha"></div>
-<script src="../components/jquery/jquery.js"></script>
-<script src="../components/mocha/mocha.js"></script>
-<script src="../components/chai/chai.js"></script>
+<script src="../bower_components/jquery/jquery.js"></script>
+<script src="../bower_components/mocha/mocha.js"></script>
+<script src="../bower_components/chai/chai.js"></script>
 <script src="/testem.js"></script>
 <script>
   mocha.setup('tdd');


### PR DESCRIPTION
Supplements:
- The Bower changed dirname for storing modules from `components` to `bower_components`.
- I did to use local `mocha` and `testem` commands, even if it was already installed in global.

By the way, as reference, I have passed manual tests in the following cases:
- Mac OSX & Chrome
- Mac OSX & Safari
- Win8 & IE10
- Win8 & IE9

I didn't test for IE8 & IE7, because "chai" did not work in these  browsers.
